### PR TITLE
lavabo: change default location of lavabo.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install lavabo dependency:
  # apt-get install python-paramiko
 ```
 
-Complete the lavabo.conf with the appropriate settings.
+Copy ```lavabo.conf`` as ```$HOME/.lavabo.conf``` and adapt it with the appropriate settings.
 
 ## F.A.Q
 

--- a/lavabo
+++ b/lavabo
@@ -29,7 +29,7 @@ import time
 from ConfigParser import ConfigParser
 
 parser = argparse.ArgumentParser(description="Client to connect to lavabo-server used to remote control boards in LAVA.")
-parser.add_argument("-c", "--conf-file", type=argparse.FileType("r"), default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "lavabo.conf"), help="the location of lavaboconfiguration file. Default: ./lavabo.conf.")
+parser.add_argument("-c", "--conf-file", type=argparse.FileType("r"), default=os.path.join(os.path.expanduser("~"), ".lavabo.conf"), help="the location of lavaboconfiguration file. Default: $HOME/.lavabo.conf.")
 
 subparsers = parser.add_subparsers(dest='cmd', help="subcommands help")
 


### PR DESCRIPTION
This commit changes the default location where lavabo searches its
configuration file. Rather than using the same directory as the
directory where the lavabo script is placed, load it from
$HOME/.lavabo.conf.

This is more Unix style, it avoids modifying a file that is under
version control, and potentially opens up for a system-wide
installation of lavabo.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
